### PR TITLE
Removal of hardcoded RTS write (#$60) at $35FC

### DIFF
--- a/real/sa_c6502_inject/cpu.c
+++ b/real/sa_c6502_inject/cpu.c
@@ -246,7 +246,6 @@ int __declspec(dllexport) C6502_JSR(WORD* adr, BYTE* areg, BYTE* xreg, BYTE* yre
     if (!strncmp(g_memory+0x3182, "TRACKER ", 8)) {
         fprintf(stderr, "%s: TRACKER tag found, load tracker.obx\n", __func__);
         load_xex("tracker.obx", g_memory);
-        g_memory[0x35fc] = 0x60;    // PATCH RTS BACK IN!
     }
 #endif
 


### PR DESCRIPTION
This is no longer necessary with my newer .obx code, the RTS will always be at the right location since the pointers will be overwritten to match their actual addresses.